### PR TITLE
Remove redundant version checking and add windows build workaround

### DIFF
--- a/src/pr/testing.md
+++ b/src/pr/testing.md
@@ -119,6 +119,9 @@ os:
 - osx
 - windows
 
+install:
+- if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install windows-sdk-10.0; fi # windows workaround (for now)
+
 script:
 - cargo check --verbose
 - cargo test --verbose
@@ -130,6 +133,9 @@ cache:
 Highlights
 - `sudo: false`: Allows Travis to do some optimizations
 - `os`: Applies all tests to listed operating systems
+- `install`: Windows workaround to allow rust to run properly.  Remove if you
+  are not testing on Windows.  Hopefully temporary as Travis CI _just_ started
+  Windows support as of 2018-10-11.
 - `cargo check`: Only needed if your project has a `[[bin]]`.  Ensure that that
   builds type. `check` delivers faster turnaround than doing `cargo build`
   since we don't care about the build artifact.

--- a/src/pr/testing.md
+++ b/src/pr/testing.md
@@ -119,10 +119,6 @@ os:
 - osx
 - windows
 
-install:
-- rustc -Vv
-- cargo -V
-
 script:
 - cargo check --verbose
 - cargo test --verbose
@@ -134,7 +130,6 @@ cache:
 Highlights
 - `sudo: false`: Allows Travis to do some optimizations
 - `os`: Applies all tests to listed operating systems
-- `install`: print tool versions for traceability
 - `cargo check`: Only needed if your project has a `[[bin]]`.  Ensure that that
   builds type. `check` delivers faster turnaround than doing `cargo build`
   since we don't care about the build artifact.


### PR DESCRIPTION
Sorry for the doubly whammy but its easier than the conflicts or waiting until later to avoid conflicts.

This removes redundant version checking as in crate-ci/meta#24 like we did in example-base and example-bin.

This additionally adds a script to the install key to workaround current Travis CI issues with windows builds.  Thanks @CAD97 